### PR TITLE
Add vibration feedback and permission for QR scan actions

### DIFF
--- a/Aetherworks-casus-2/MVVM/ViewModels/QRscanViewModel.cs
+++ b/Aetherworks-casus-2/MVVM/ViewModels/QRscanViewModel.cs
@@ -75,12 +75,17 @@ namespace Aetherworks_casus_2.MVVM.ViewModels
             {
                 userParticipation.Attend = true;
                 _dbService.AddOrUpdateParticipation(userParticipation);
+
+                Vibration.Default.Vibrate(TimeSpan.FromMilliseconds(500));
+
                 await Application.Current.MainPage.DisplayAlert("Attendance Marked", $"User {userId} marked as attended for Activity {activityId}.", "OK");
 
                 Application.Current.MainPage.Navigation.PopAsync();
             }
             else
             {
+                Vibration.Default.Vibrate(TimeSpan.FromMilliseconds(500));
+
                 await Application.Current.MainPage.DisplayAlert("Error", "User is not registered for this activity.", "OK");
 
                 Application.Current.MainPage.Navigation.PopAsync();
@@ -96,12 +101,17 @@ namespace Aetherworks_casus_2.MVVM.ViewModels
             {
                 selfParticipation.Attend = true;
                 _dbService.AddOrUpdateParticipation(selfParticipation);
+
+                Vibration.Default.Vibrate(TimeSpan.FromMilliseconds(500));
+
                 Application.Current.MainPage.DisplayAlert("Attendance Confirmed", "You have been marked as attended.", "OK");
 
                 Application.Current.MainPage.Navigation.PopAsync();
             }
             else
             {
+                Vibration.Default.Vibrate(TimeSpan.FromMilliseconds(500));
+
                 Application.Current.MainPage.DisplayAlert("Error", "You are not registered for this activity.", "OK");
 
                 Application.Current.MainPage.Navigation.PopAsync();

--- a/Aetherworks-casus-2/Platforms/Android/AndroidManifest.xml
+++ b/Aetherworks-casus-2/Platforms/Android/AndroidManifest.xml
@@ -5,4 +5,5 @@
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 	<uses-permission android:name="android.permission.CAMERA" />
+	<uses-permission android:name="android.permission.VIBRATE" />
 </manifest>


### PR DESCRIPTION
Added vibration feedback in `QRscanViewModel.cs` for marking attendance and handling errors when a user is not registered for an activity. Updated `AndroidManifest.xml` to include `android.permission.VIBRATE` for enabling vibration feature.